### PR TITLE
Upgrade to Fabric 1.21.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ hs_err_*.log
 replay_*.log
 *.hprof
 *.jfr
+
+gradlew
+gradlew.bat

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.9-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.9
-loader_version=0.15.11
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.8
+loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.7
+mod_version=1.8
 maven_group=fabric.safeserver
 archives_base_name=safeserver
 
 # Dependencies
-fabric_version=0.101.2+1.21
+fabric_version=0.117.0+1.21.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/fabric/safeserver/Safeserver.java
+++ b/src/main/java/fabric/safeserver/Safeserver.java
@@ -6,6 +6,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.network.packet.s2c.play.PositionFlag;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -18,6 +19,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -202,7 +204,7 @@ public class Safeserver implements ModInitializer {
 	}
 
 	private void teleportPlayerToJoinPosition(ServerPlayerEntity player, Vec3d joinPos) {
-		player.teleport(player.getServerWorld(), joinPos.x, joinPos.y, joinPos.z, player.getYaw(), player.getPitch());
+		player.teleport(player.getServerWorld(), joinPos.x, joinPos.y, joinPos.z, new HashSet<PositionFlag>(), player.getYaw(), player.getPitch(), false);
 		player.changeGameMode(GameMode.SPECTATOR);
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.9",
-		"minecraft": "~1.21",
+		"minecraft": "~1.21.4",
 		"java": ">=17",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
- Update dependencies version to match Fabric 1.21.4
- Fix ```ServerPlayerEntity.teleport()``` args to match 1.21.4